### PR TITLE
Tell GitHub to syntax-highlight `config.sh`s

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh_* linguist-language=Shell


### PR DESCRIPTION
Add `.gitattributes` in order [to tell GitHub](https://github.com/github/linguist/blob/master/docs/overrides.md#using-gitattributes) to highlight the files as shell.

I was curious whether this would work. It seems like it does. 